### PR TITLE
Add GitHub Actions CI workflow and additional PHP classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,139 @@
+name: "CI Tests"
+
+on:
+    pull_request:
+    push:
+
+jobs:
+  php81:
+    name: PHP 8.1
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP 8.1"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.1"
+
+      - name: "Cache composer packages"
+        uses: "actions/cache@v3"
+        with:
+          path: "~/.composer/cache"
+          key: "php-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-composer-locked-"
+
+      - name: "Install dependencies with composer"
+        run: "composer install --no-interaction --prefer-dist"
+
+      - name: "Run unit tests"
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          composer test-unit
+          composer global require php-coveralls/php-coveralls
+          php-coveralls --coverage_clover=build/output/tests/coverage.xml --json_path=build/output/tests/coveralls-upload.json -v
+
+      - name: "Run acceptance tests"
+        run: "composer test-acceptance"
+
+      - name: "Run PHP CS Check"
+        run: "composer cs-check"
+
+      - name: "Run Psalm"
+        run: "composer psalm"
+
+      - name: "PHP Lint"
+        run: "composer lint"
+
+      - name: "Run infection"
+        env:
+          INFECTION_BADGE_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        run: "composer infection"
+
+  php82:
+    name: PHP 8.2
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP 8.2"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.2"
+
+      - name: "Cache composer packages"
+        uses: "actions/cache@v3"
+        with:
+          path: "~/.composer/cache"
+          key: "php-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-composer-locked-"
+
+      - name: "Install dependencies with composer"
+        run: "composer install --no-interaction --prefer-dist"
+
+      - name: "Run unit tests"
+        run: "composer test-unit"
+
+      - name: "Run acceptance tests"
+        run: "composer test-acceptance"
+
+      - name: "Run PHP CS Check"
+        run: "PHP_CS_FIXER_IGNORE_ENV=1 composer cs-check"
+
+      - name: "Run Psalm"
+        run: "composer psalm"
+
+      - name: "PHP Lint"
+        run: "composer lint"
+
+      - name: "Run infection"
+        run: "composer infection"
+
+  php83:
+    name: PHP 8.3
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP 8.3"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.3"
+
+      - name: "Cache composer packages"
+        uses: "actions/cache@v3"
+        with:
+          path: "~/.composer/cache"
+          key: "php-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-composer-locked-"
+
+      - name: "Install dependencies with composer"
+        run: "composer install --no-interaction --prefer-dist"
+
+      - name: "Run unit tests"
+        run: "composer test-unit"
+
+      - name: "Run acceptance tests"
+        run: "composer test-acceptance"
+
+      - name: "Run PHP CS Check"
+        run: "PHP_CS_FIXER_IGNORE_ENV=1 composer cs-check"
+
+      - name: "Run Psalm"
+        run: "composer psalm"
+
+      - name: "PHP Lint"
+        run: "composer lint"
+
+      - name: "Run infection"
+        run: "composer infection"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea
+.phpunit.result.cache
+/vendor/
+composer.lock
+/bin/
+/tmp/
+/html/
+/build

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude(['vendor', 'bin', 'build'])
+    ->in(__DIR__)
+;
+
+$config = new PhpCsFixer\Config();
+return $config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'braces' => false,
+        'array_indentation' => true,
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
+        'blank_line_after_opening_tag' => false,
+        'blank_line_before_statement' => true,
+        'cast_spaces' => true,
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
+        'declare_equal_normalize' => true,
+        'include' => true,
+        'function_typehint_space' => true,
+        'linebreak_after_opening_tag' => true,
+        'lowercase_cast' => true,
+        'lowercase_static_reference' => true,
+        'magic_constant_casing' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'new_with_braces' => true,
+        'no_alternative_syntax' => true,
+        'no_empty_comment' => true,
+        'no_empty_statement' => true,
+        'no_closing_tag' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unneeded_curly_braces' => true,
+        'no_unneeded_final_method' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'normalize_index_brace' => true,
+        'object_operator_without_whitespace' => true,
+        'ordered_imports' => true,
+        'phpdoc_annotation_without_dot' => true,
+        'phpdoc_indent' => true,
+        'phpdoc_no_access' => true,
+        'return_type_declaration' => true,
+        'short_scalar_cast' => true,
+        'simplified_null_return' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_quote' => true,
+        'standardize_not_equals' => true,
+        'ternary_operator_spaces' => true,
+        'ternary_to_null_coalescing' => true,
+        'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
+        'visibility_required' => true,
+        'trailing_comma_in_multiline' => true,
+        'yoda_style' => false,
+
+        /** @risky */
+        'strict_comparison' => true,
+        'dir_constant' => true,
+    ])->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,54 @@
+{
+  "name": "marcel-strahl/container",
+  "description": "A simple and clean PHP container based on PSR-11",
+  "keywords": ["psr-11", "11", "psr", "container", "PHP", "php", "DI", "di", "dependency injection", "dependency", "injection"],
+  "minimum-stability": "stable",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Marcel Strahl",
+      "email": "info@marcel-strahl.de"
+    }
+  ],
+  "scripts": {
+    "psalm": "psalm --no-cache",
+    "lint": "parallel-lint --exclude .git --exclude vendor bin .",
+    "cs-check": "php-cs-fixer -v --dry-run --using-cache=no fix",
+    "cs-fix": "php-cs-fixer --using-cache=no fix",
+    "test-unit": "export XDEBUG_MODE=coverage && phpunit --configuration phpunit.xml.dist --testsuite Unit",
+    "test-acceptance": "export XDEBUG_MODE=coverage && phpunit --configuration phpunit.xml.dist --testsuite Acceptance",
+    "infection": "infection --threads=4 --coverage=build/output/tests"
+  },
+  "config":{
+    "bin-dir": "bin",
+    "allow-plugins": {
+      "infection/extension-installer": true
+    }
+  },
+  "prefer-stable": true,
+  "autoload": {
+    "psr-4": {
+      "MarcelStrahl\\Container\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "MarcelStrahl\\Tests\\": "tests/"
+    }
+  },
+  "require": {
+    "php": "^8.1",
+    "psr/container": "^2.0",
+    "webmozart/assert": "^1.11"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5",
+    "roave/security-advisories": "dev-latest",
+    "friendsofphp/php-cs-fixer": "^3.13",
+    "php-parallel-lint/php-parallel-lint": "^1.3",
+    "vimeo/psalm": "^5.6",
+    "psalm/plugin-phpunit": "^0.18.4",
+    "infection/infection": "^0.27.9"
+  }
+}

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,22 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "mutators": {
+        "@default": true
+    },
+    "logs": {
+        "html": "build/output/tests/infection/infection.html",
+        "summary": "build/output/tests/infection/summary.log",
+        "json": "build/output/tests/infection/infection-log.json",
+        "perMutator": "build/output/tests/infection/per-mutator.md",
+        "github": true,
+        "stryker": {
+            "badge": "master"
+        },
+        "summaryJson": "build/output/tests/infection/summary.json"
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd" bootstrap="vendor/autoload.php" backupGlobals="false" executionOrder="random" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory>./bin</directory>
+            <directory>./tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+        <report>
+            <clover outputFile="build/output/tests/coverage/clover.xml"/>
+            <cobertura outputFile="build/output/tests/coverage/cobertura.xml"/>
+            <php outputFile="build/output/tests/coverage/coverage.php"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+            <html outputDirectory="build/output/tests/coverage/html" lowUpperBound="50" highLowerBound="90"/>
+            <xml outputDirectory="build/output/tests/coverage/xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/output/tests/logging/junit.xml"/>
+    </logging>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Acceptance">
+            <directory suffix="Test.php">tests/Acceptance</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Delegator/ObjectDelegator.php
+++ b/src/Delegator/ObjectDelegator.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace MarcelStrahl\Container\Delegator;
+
+use function class_implements;
+use function in_array;
+
+use MarcelStrahl\Container\Factory\FactoryInterface;
+use MarcelStrahl\Container\ObjectBuilder\ObjectBuilderFactoryInterface;
+use function method_exists;
+
+final class ObjectDelegator implements DelegateInterface
+{
+    public function __construct(private ObjectBuilderFactoryInterface $builderFactory)
+    {
+    }
+
+    public function delegate(string $class): object
+    {
+        $interfaces = class_implements($class);
+        $isFactory = in_array(FactoryInterface::class, $interfaces, true);
+        if (!$isFactory) {
+            $isFactory = method_exists($class, '__invoke');
+        }
+
+        $type = ObjectBuilderFactoryInterface::BUILDER_REFLECTION;
+        if ($isFactory) {
+            $type = ObjectBuilderFactoryInterface::BUILDER_FACTORY;
+        }
+
+        $builder = $this->builderFactory->factorize($type);
+
+        return $builder->initialize($class);
+    }
+}

--- a/src/ObjectBuilder/FactoryBuilder.php
+++ b/src/ObjectBuilder/FactoryBuilder.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace MarcelStrahl\Container\ObjectBuilder;
+
+use function class_exists;
+use function is_callable;
+use MarcelStrahl\Container\Exception\NotFoundInContainerException;
+
+use MarcelStrahl\Container\Factory\FactoryInterface;
+use function method_exists;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @author Marcel Strahl <info@marcel-strahl.de>
+ */
+final class FactoryBuilder implements ObjectBuilder
+{
+    public function __construct(private ContainerInterface $container, private ObjectBuilder $reflectionBuilder)
+    {
+    }
+
+    public function initialize(callable|string $class): object
+    {
+        if (is_callable($class)) {
+            return $class($this->container);
+        }
+
+        if (!class_exists($class)) {
+            throw NotFoundInContainerException::create($class);
+        }
+
+        $factory = $this->reflectionBuilder->initialize($class);
+        if (method_exists($factory, '__invoke')) {
+
+            return $factory->__invoke($this->container);
+        }
+
+        if (!$factory instanceof FactoryInterface) {
+            throw NotFoundInContainerException::create($class);
+        }
+
+        return $factory->factorize($this->container);
+    }
+}

--- a/src/ObjectBuilder/ObjectBuilderFactory.php
+++ b/src/ObjectBuilder/ObjectBuilderFactory.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace MarcelStrahl\Container\ObjectBuilder;
+
+use MarcelStrahl\Container\Exception\ObjectBuilderFactory\UnknownBuilderTypeException;
+use Psr\Container\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+final class ObjectBuilderFactory implements ObjectBuilderFactoryInterface
+{
+    private ?ContainerInterface $container;
+
+    public function __construct()
+    {
+        $this->container = null;
+    }
+
+    /**
+     * @psalm-param self::BUILDER_*|'' $builderType
+     * @throws UnknownBuilderTypeException
+     */
+    public function factorize(string $builderType): ObjectBuilder
+    {
+        $container = $this->container;
+
+        Assert::isInstanceOf(
+            $container,
+            ContainerInterface::class,
+            'It is important that you set the container before calling `factorize`.',
+        );
+
+        $reflectionBuilder = new ReflectionBuilder();
+
+        return match ($builderType) {
+            self::BUILDER_REFLECTION => $reflectionBuilder,
+            self::BUILDER_FACTORY => new FactoryBuilder($container, $reflectionBuilder),
+            default => throw UnknownBuilderTypeException::create($builderType),
+        };
+    }
+
+    public function setContainer(ContainerInterface $container): void
+    {
+        $this->container = $container;
+    }
+}

--- a/tests/Unit/FileLoader/PhpArrayAdapterTest.php
+++ b/tests/Unit/FileLoader/PhpArrayAdapterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcelStrahl\Tests\Unit\FileLoader;
+
+use MarcelStrahl\Container\Dto\ClassStore\ClassItem;
+use MarcelStrahl\Container\Dto\ClassStoreInterface;
+use MarcelStrahl\Container\Exception\NonExistingFileException;
+use MarcelStrahl\Container\Exception\UnknownFileExtensionException;
+use MarcelStrahl\Container\FileLoader\PHPArrayAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Marcel Strahl <info@marcel-strahl.de>
+ *
+ * @internal
+ */
+final class PhpArrayAdapterTest extends TestCase
+{
+    /**
+     * @psalm-var MockObject&ClassStoreInterface
+     */
+    /* MockObject&ClassStoreInterface */ private $store;
+
+    protected function setUp(): void
+    {
+        $this->store = $this->createMock(ClassStoreInterface::class);
+    }
+
+    public function testCanNotLoadFromFilePathWithNoneExistingFile(): void
+    {
+        $this->expectException(NonExistingFileException::class);
+
+        $path = 'non/existing/config';
+
+        $fileLoader = new PHPArrayAdapter();
+
+        $fileLoader->loadFileFromPath($path, $this->store);
+    }
+
+    public function testCanNotLoadFromFilePathBecauseItHasNotRequiredPHPExtension(): void
+    {
+        $this->expectException(UnknownFileExtensionException::class);
+
+        $path = sprintf('%s/config', __DIR__);
+        static::assertNotEmpty($path);
+
+        $fileLoader = new PHPArrayAdapter();
+
+        $fileLoader->loadFileFromPath($path, $this->store);
+    }
+
+    public function testCanLoadFromFilePathSuccessful(): void
+    {
+        $path = sprintf('%s/php_array_config.php', __DIR__);
+        static::assertNotEmpty($path);
+
+        $content = include $path;
+
+        $classItems = [];
+        foreach ($content as $class => $item) {
+            $classItems[] = [ClassItem::create($class, $item)];
+        }
+
+        $this->store->expects(static::exactly(4))->method('append')->withConsecutive(...$classItems);
+
+        $fileLoader = new PHPArrayAdapter();
+        $fileLoader->loadFileFromPath($path, $this->store);
+    }
+
+    public function testCanLoadFromMoreThanOneFilePaths(): void
+    {
+        $pathOne = sprintf('%s/php_array_config.php', __DIR__);
+        Assert::stringNotEmpty($pathOne);
+        $pathTwo = sprintf('%s/array_config.php', __DIR__);
+        Assert::stringNotEmpty($pathTwo);
+
+        $paths = [
+            $pathOne,
+            $pathTwo,
+        ];
+
+        $classItems = [];
+        foreach ($paths as $path) {
+            $content = include $path;
+
+            foreach ($content as $class => $item) {
+                $classItems[] = [ClassItem::create($class, $item)];
+            }
+        }
+
+        $this->store
+            ->expects(static::exactly(7))
+            ->method('append')
+            ->withConsecutive(...$classItems)
+        ;
+
+        $fileLoader = new PHPArrayAdapter();
+        $fileLoader->loadFileFromPaths($paths, $this->store);
+    }
+}

--- a/tests/Unit/ObjectBuilder/ReflectionBuilderTest.php
+++ b/tests/Unit/ObjectBuilder/ReflectionBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcelStrahl\Tests\Unit\ObjectBuilder;
+
+use LogicException;
+use MarcelStrahl\Container\Exception\ObjectBuilder\CanNotCreateClassWithNoneClassDependencies;
+use MarcelStrahl\Container\ObjectBuilder\ObjectBuilder;
+use MarcelStrahl\Container\ObjectBuilder\ReflectionBuilder;
+use MarcelStrahl\Tests\Unit\ObjectBuilder\_data\SimpleTestServiceWithConstructorAndNonClassDependency;
+use MarcelStrahl\Tests\Unit\ObjectBuilder\_data\SimpleTestServiceWithConstructorAndOneDependency;
+use MarcelStrahl\Tests\Unit\ObjectBuilder\_data\SimpleTestServiceWithConstructorButWithoutDependencies;
+use MarcelStrahl\Tests\Unit\ObjectBuilder\_data\SimpleTestServiceWithoutConstructor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ */
+final class ReflectionBuilderTest extends TestCase
+{
+    public function testCanInitialize(): void
+    {
+        $builder = new ReflectionBuilder();
+
+        static::assertInstanceOf(ObjectBuilder::class, $builder);
+    }
+
+    public function testCanInitializeSimpleClassWithoutConstructor(): void
+    {
+        $builder = new ReflectionBuilder();
+
+        $object = $builder->initialize(SimpleTestServiceWithoutConstructor::class);
+
+        static::assertInstanceOf(SimpleTestServiceWithoutConstructor::class, $object);
+    }
+
+    public function testCanInitializeSimpleClassWithConstructorButWithoutDependencies(): void
+    {
+        $builder = new ReflectionBuilder();
+
+        $object = $builder->initialize(SimpleTestServiceWithConstructorButWithoutDependencies::class);
+
+        static::assertInstanceOf(SimpleTestServiceWithConstructorButWithoutDependencies::class, $object);
+    }
+
+    public function testCanInitializeSimpleClassWithConstructorAndOneDependency(): void
+    {
+        $builder = new ReflectionBuilder();
+
+        $object = $builder->initialize(SimpleTestServiceWithConstructorAndOneDependency::class);
+
+        static::assertInstanceOf(SimpleTestServiceWithConstructorAndOneDependency::class, $object);
+    }
+
+    public function testCanNotInitializeNonExistingClass(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot find your class, try `composer dumpautoload` command.');
+
+        $builder = new ReflectionBuilder();
+
+        $builder->initialize('X\Dummy\Namespace\Class');
+    }
+
+    public function testCanNotInitializeNonClassDependency(): void
+    {
+        $this->expectException(CanNotCreateClassWithNoneClassDependencies::class);
+        $this->expectExceptionMessage('Currently, no object can be created with non-class dependencies, given type "int".');
+
+        $builder = new ReflectionBuilder();
+
+        $builder->initialize(SimpleTestServiceWithConstructorAndNonClassDependency::class);
+    }
+
+    /**
+     * @test
+     */
+    public function throwLogicExceptionWhenReflectionBuilderIsPassedCallables(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('callables are not yet supported.');
+
+        $closure = static function (): string {
+            return 'dummy';
+        };
+
+        $builder = new ReflectionBuilder();
+
+        $builder->initialize($closure);
+    }
+}

--- a/tests/Unit/ObjectContainerTest.php
+++ b/tests/Unit/ObjectContainerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcelStrahl\Tests\Unit;
+
+use MarcelStrahl\Container\Delegator\DelegateInterface;
+use MarcelStrahl\Container\Dto\ObjectStoreInterface;
+use MarcelStrahl\Container\Exception\NotFoundInContainerException;
+use MarcelStrahl\Container\ObjectContainer;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ *
+ */
+final class ObjectContainerTest extends TestCase
+{
+    /**
+     * @psalm-var MockObject&ObjectStoreInterface
+     */
+    private MockObject/* &ObjectStoreInterface */ $store;
+
+    /**
+     * @psalm-var MockObject&DelegateInterface
+     */
+    private MockObject/* &ObjectBuilder */ $delegator;
+
+    protected function setUp(): void
+    {
+        $this->store = $this->createMock(ObjectStoreInterface::class);
+        $this->delegator = $this->createMock(DelegateInterface::class);
+    }
+
+    public function testCanInitialize(): void
+    {
+        $container = new ObjectContainer($this->store, $this->delegator);
+
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+    }
+
+    public function testCanGetObjectFromContainer(): void
+    {
+        $dummy = new class() {};
+
+        $this->store
+            ->expects(static::once())
+            ->method('searchById')
+            ->with($dummy::class)
+            ->willReturn($dummy)
+        ;
+
+        $container = new ObjectContainer($this->store, $this->delegator);
+
+        $object = $container->get($dummy::class);
+
+        static::assertInstanceOf($dummy::class, $object);
+    }
+
+    public function testCanNotGetContainerWhenClassNotExist(): void
+    {
+        $dummy = new class() {};
+
+        $this->expectException(NotFoundInContainerException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Can not found a entry in container with given id "%s"',
+            $dummy::class,
+        ));
+
+        $exception = new \LogicException();
+
+        $this->delegator
+            ->expects(self::once())
+            ->method('delegate')
+            ->with($dummy::class)
+            ->willThrowException($exception)
+        ;
+
+        $this->store
+            ->expects(self::once())
+            ->method('searchById')
+            ->with($dummy::class)
+            ->willReturn(null)
+        ;
+
+        $container = new ObjectContainer($this->store, $this->delegator);
+
+        $object = $container->get($dummy::class);
+
+        $this->assertInstanceOf($dummy::class, $object);
+    }
+
+    public function testInitializeObjectWhenClassNotExistInObjectContainer(): void
+    {
+        $dummy = new class() {};
+
+        $this->delegator
+            ->expects(static::once())
+            ->method('delegate')
+            ->with($dummy::class)
+            ->willReturn($dummy)
+        ;
+
+        $this->store
+            ->expects(static::once())
+            ->method('searchById')
+            ->with($dummy::class)
+            ->willReturn(null)
+        ;
+
+        $this->store
+            ->expects(static::once())
+            ->method('append')
+            ->with($dummy::class, $dummy)
+        ;
+
+        $container = new ObjectContainer($this->store, $this->delegator);
+
+        $container->get($dummy::class);
+
+        static::assertInstanceOf($dummy::class, $dummy);
+    }
+
+    public function testCheckContainerHasObject(): void
+    {
+        $dummy = new class() {};
+
+        $this->store
+            ->expects(static::once())
+            ->method('searchById')
+            ->with($dummy::class)
+            ->willReturn($dummy)
+        ;
+
+        $container = new ObjectContainer($this->store, $this->delegator);
+
+        static::assertTrue($container->has($dummy::class));
+    }
+
+    public function testCheckContainerHasNotObject(): void
+    {
+        $dummy = new class() {};
+
+        $this->store
+            ->expects(static::once())
+            ->method('searchById')
+            ->with($dummy::class)
+            ->willReturn(null)
+        ;
+
+        $container = new ObjectContainer($this->store, $this->delegator);
+
+        static::assertFalse($container->has($dummy::class));
+    }
+}


### PR DESCRIPTION
This commit introduces a new file for CI workflows integrating GitHub Actions for testing different PHP versions. It also adds new ObjectBuilder and FileLoader classes and their corresponding unit tests. Furthermore, the configuration for PHPUnit, php-cs-fixer, and Infection has been added. '.gitignore' file has also been created to exclude certain files and directories from versioning.